### PR TITLE
TRT-627: Implement workflow identifying all Harmony services.

### DIFF
--- a/.github/workflows/test_all_associated_collections.yaml
+++ b/.github/workflows/test_all_associated_collections.yaml
@@ -11,6 +11,7 @@ jobs:
   identify_all_services:
     runs-on: ubuntu-latest
     environment: production
+    name: Identify All Harmony Services
     outputs:
       all_services: "${{ steps.find_all_services.outputs.all_services }}"
 

--- a/.github/workflows/test_all_associated_collections.yaml
+++ b/.github/workflows/test_all_associated_collections.yaml
@@ -1,0 +1,53 @@
+# This workflow will be executed when a full execution of all
+# collections associated with all collections should be performed.
+name: Full Harmony Autotester run
+
+on:
+  schedule:
+    # Currently scheduled every morning at 2:05am.
+    - cron: "5 2 * * *"
+
+jobs:
+  identify_all_services:
+    runs-on: ubuntu-latest
+    environment: production
+    outputs:
+      all_services: "${{ steps.find_all_services.outputs.all_services }}"
+
+    steps:
+      - name: Checkout nasa/harmony-autotester repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python 3.12 environment
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r bin/requirements.txt
+
+      - name: Find all services and associated collections
+        id: "find_all_services"
+        run: |
+          python bin/get_all_services.py
+        env:
+          CMR_GRAPHQL_URL: ${{ vars.CMR_GRAPHQL_URL }}
+          EDL_URL: ${{ vars.EDL_URL }}
+          EDL_USER: ${{ secrets.EDL_USER }}
+          EDL_PASSWORD: ${{ secrets.EDL_PASSWORD }}
+
+  test_all_services:
+    runs-on: ubuntu-latest
+    environment: production
+    needs: identify_all_services
+    strategy:
+      matrix:
+        service: ${{ fromJson(needs.identify_all_services.outputs.all_services) }}
+    name: ${{ matrix.service.name }}
+
+    steps:
+      - name: Placeholder to prove matrix is working
+        run: |
+          echo "${{ matrix.service.name }} is ${{ matrix.service.concept_id }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]: https://github.com/nasa/harmony-autotester
 
+### Added:
+
+- TRT-627 - Implemented workflow to retrieve all Harmony services from CMR GraphQL
+  along with all associated collections.
+
 TODO
 
 [unreleased]: https://github.com/nasa/harmony-autotester/

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ TODO
 |- LICENSE
 |- README.md
 |- dev_requirements.txt
+|- pyproject.toml
 ```
 
 * `.github` contains CI/CD workflows to be executed within the repository. For
@@ -46,6 +47,8 @@ TODO
 * `README.md` is this file.
 * `dev_requirements.txt` contains Pip-installable Python packages that are
   required for local development. For example, `pre-commit`.
+* `pyproject.toml`  is a configuration file used by packaging tools, and other
+  tools such as linters and type checkers.
 
 ## CI/CD workflows:
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,17 @@ or obviously incorrect output.
 
 ## What the Harmony Autotester does:
 
-TODO
+The Harmony Autotester provides simple, non-rigorous testing of all NASA
+Earth Science collections supported by the [Harmony](https://harmony.earthdata.nasa.gov)
+workflow manager.
+
+All Harmony services are identified using the Common Metadata Repository (CMR),
+and all collections associated with those services are also retrieved. For each
+service, a set of basic tests are executed for all associated services,
+primarily ensuring the request succeeds.
+
+If a test fails for a collection/service pairing, a GitHub issue will be created
+in the repository, to allow for tracking of any related issues.
 
 ## Repository Structure:
 
@@ -52,7 +62,13 @@ TODO
 
 ## CI/CD workflows:
 
-TODO
+These are found in the `.github/workflows` directory:
+
+- `test_all_associated_collections.yaml` contains the main workflow for the
+  Harmony Autotester, which is triggered on a nightly schedule. This workflow
+  uses CMR to identify all Harmony services and their associated collections,
+  before triggering the appropriate test suite to run for all collections
+  associated with a particular service.
 
 ## Releasing:
 

--- a/bin/get_all_services.py
+++ b/bin/get_all_services.py
@@ -1,0 +1,275 @@
+"""Module to identify all Harmony services and their associated collections.
+
+The information retrieved is written to the file containing GitHub environment
+variables, specified by the `GITHUB_OUTPUT` environment variable. This is done
+so that later workflow jobs can use the output as the basis for a matrix to
+parallelise testing.
+
+"""
+
+import json
+import os
+
+import requests
+
+
+def get_edl_bearer_token(edl_url: str, edl_user: str, edl_password: str) -> str:
+    """Retrieve an Earthdata Login (EDL) token.
+
+    This function uses an EDL username and password, which are stored in the
+    GitHub repository as secrets, instead of relying on a .netrc file.
+
+    """
+    existing_tokens_response = requests.get(
+        f'{edl_url}/api/users/tokens',
+        headers={'Content-type': 'application/json'},
+        auth=(edl_user, edl_password),
+        timeout=10,
+    )
+    existing_tokens_response.raise_for_status()
+    existing_tokens_json = existing_tokens_response.json()
+
+    if len(existing_tokens_json) == 0:
+        new_token_response = requests.post(
+            f'{edl_url}/api/users/token',
+            headers={'Content-type': 'application/json'},
+            auth=(edl_user, edl_password),
+            timeout=10,
+        )
+        new_token_response.raise_for_status()
+        new_token_json = new_token_response.json()
+        edl_token = new_token_json['access_token']
+    else:
+        edl_token = existing_tokens_json[0]['access_token']
+
+    return edl_token
+
+
+def get_authenticated_session(
+    edl_url: str, edl_user: str, edl_password: str
+) -> requests.Session:
+    """Create a `requests.Session` object that is authorised via Earthdata login.
+
+    The returned session object will contain an `Authorization` header
+    containing an EDL bearer token, which will be automatically used in all
+    requests made via that session.
+
+    """
+    edl_bearer_token = get_edl_bearer_token(edl_url, edl_user, edl_password)
+    session = requests.session()
+    session.headers.update(
+        {
+            'Authorization': f'Bearer {edl_bearer_token}',
+        }
+    )
+    return session
+
+
+def get_service_collections(
+    authenticated_session: requests.Session,
+    cmr_graphql_url: str,
+    service_concept_id: str,
+) -> list[dict[str, str]]:
+    """Identify all collections associated with the given Harmony service.
+
+    Perform a Service query against CMR GraphQL to retrieve all collections
+    associated with the service, as specified by the service concept ID.
+
+    """
+    print(f'Retrieving collections for {service_concept_id}')
+    query_parameters = {
+        'serviceParams': {
+            'conceptId': service_concept_id,
+        },
+        'collectionsParams': {'cursor': None, 'limit': 100},
+    }
+
+    query_string = """
+    query Service($serviceParams: ServiceInput, $collectionsParams: CollectionsInput) {
+      service(params: $serviceParams) {
+        collections(params: $collectionsParams) {
+          items {
+            conceptId
+            shortName
+            version
+          }
+          cursor
+        }
+      }
+    }
+    """
+
+    request_json = {
+        'operationName': 'Service',
+        'query': query_string,
+        'variables': query_parameters,
+    }
+
+    cursor = 'not null'
+
+    # The error count and limit prevent infinite loops from repeated errors:
+    max_errors = 3
+    error_count = 0
+
+    collections = []
+    # Perform paginated request - this ensures services associated with many
+    # collections will still succeed.
+    # Requests will continue until all services have been retrieved
+    while error_count < max_errors and cursor is not None:
+        cmr_graph_response = authenticated_session.post(
+            url=cmr_graphql_url, json=request_json, timeout=10
+        )
+
+        if cmr_graph_response.ok:
+            json_data = cmr_graph_response.json()
+
+            # Extract collection information for service
+            collections.extend(
+                [
+                    {
+                        'concept_id': collection['conceptId'],
+                        'short_name': collection['shortName'],
+                        'version': collection['version'],
+                    }
+                    for collection in json_data['data']['service']['collections'][
+                        'items'
+                    ]
+                ]
+            )
+
+            # Update the cursor for paginated requests
+            cursor = json_data['data']['service']['collections']['cursor']
+            request_json['variables']['collectionsParams']['cursor'] = cursor
+        else:
+            error_count += 1
+            print(f'response status code: f{cmr_graph_response.status_code}')
+            print(f'response : {cmr_graph_response.content}')
+
+    return collections
+
+
+def get_all_harmony_services(
+    authenticated_session: requests.Session,
+    cmr_graphql_url: str,
+) -> list[dict]:
+    """Retrieve all Harmony services and their associated collections.
+
+    First use CMR GraphQL to identify all UMM-S records with a type of "harmony".
+    Next, for each service, query for all associated collections. This is not
+    performed as a single query, as pagination of nested items did not appear
+    to be working as expected.
+
+    A list output is chosen in preference to a dictionary for compatibility with
+    the GitHub Action matrix functionality.
+
+    """
+    print('\nRetrieving all Harmony services')
+    query_parameters = {
+        'servicesParams': {
+            'limit': 100,
+            'type': 'harmony',
+        },
+    }
+
+    query_string = """
+    query Services($servicesParams: ServicesInput) {
+      services(params: $servicesParams) {
+        count
+        items {
+          name
+          conceptId
+          version
+          collections {
+            count
+          }
+        }
+        cursor
+      }
+    }
+    """
+
+    request_json = {
+        'operationName': 'Services',
+        'query': query_string,
+        'variables': query_parameters,
+    }
+
+    # Begin with non-null cursor to satisfy while loop
+    cursor = 'not null'
+
+    # The error count and limit prevent infinite loops from repeated errors:
+    error_count = 0
+    max_errors = 3
+
+    harmony_services = []
+
+    while error_count < max_errors and cursor is not None:
+        cmr_graph_response = authenticated_session.post(
+            url=cmr_graphql_url, json=request_json, timeout=10
+        )
+
+        if cmr_graph_response.ok:
+            json_data = cmr_graph_response.json()
+
+            # Add service information to harmony_services aggregator:
+            harmony_services.extend(
+                [
+                    {
+                        'concept_id': service['conceptId'],
+                        'name': service['name'],
+                        'version': service['version'],
+                        'collection_count': service['collections']['count'],
+                    }
+                    for service in json_data['data']['services']['items']
+                ]
+            )
+
+            # Update the cursor for paginated requests
+            cursor = json_data['data']['services']['cursor']
+            request_json['variables']['servicesParams']['cursor'] = cursor
+        else:
+            error_count += 1
+            print(f'response status code: f{cmr_graph_response.status_code}')
+            print(f'response : {cmr_graph_response.content}')
+
+    # Return list that also contains information on all collections associated
+    # with each service:
+    return [
+        {
+            **harmony_service,
+            'collections': get_service_collections(
+                authenticated_session,
+                cmr_graphql_url,
+                harmony_service['concept_id'],
+            ),
+        }
+        for harmony_service in harmony_services
+    ]
+
+
+def output_all_services(harmony_services: list[dict]) -> None:
+    """Write service information to a GitHub environment variable.
+
+    This function accesses the GitHub environment file listed at the `GITHUB_OUTPUT`
+    environment variable and saved the Harmony service information as a string
+    of JSON.
+
+    This JSON will then be accessible to later workflow jobs as steps.
+
+    """
+    with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as file_handler:
+        print(f'all_services={json.dumps(harmony_services)}', file=file_handler)
+
+
+if __name__ == '__main__':
+    # Retrieve environment-specific information:
+    cmr_graphql_url = os.environ.get('CMR_GRAPHQL_URL')
+    edl_url = os.environ.get('EDL_URL')
+    edl_user = os.environ.get('EDL_USER')
+    edl_password = os.environ.get('EDL_PASSWORD')
+
+    # Retrieve all service information and write it to the file listed as
+    # GITHUB_OUTPUT.
+    authenticated_session = get_authenticated_session(edl_url, edl_user, edl_password)
+    all_services = get_all_harmony_services(authenticated_session, cmr_graphql_url)
+    output_all_services(all_services)

--- a/bin/get_all_services.py
+++ b/bin/get_all_services.py
@@ -251,10 +251,10 @@ def output_all_services(harmony_services: list[dict]) -> None:
     """Write service information to a GitHub environment variable.
 
     This function accesses the GitHub environment file listed at the `GITHUB_OUTPUT`
-    environment variable and saved the Harmony service information as a string
+    environment variable and saves the Harmony service information as a string
     of JSON.
 
-    This JSON will then be accessible to later workflow jobs as steps.
+    This JSON will then be accessible to later workflow jobs or steps.
 
     """
     with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as file_handler:

--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -1,0 +1,2 @@
+# Requirements for main workflow identifying all services:
+requests ~= 2.32.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.ruff]
+lint.select = [
+  "E",   # pycodestyle
+  "F",   # pyflakes
+  "UP",  # pyupgrade
+  "I",   # organize imports
+  "D",   # docstyle
+]
+
+[tool.ruff.format]
+quote-style = "single"
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[[tool.mypy.overrides]]
+module = "harmony_service_lib.*"
+ignore_missing_imports = true


### PR DESCRIPTION
## Description

This PR implements a GitHub workflow to identify all Harmony services. Basic information for each service (concept ID, name, version) is retrieved from CMR GraphQL, as is a list of all collections associated with each service.

The output from the Python module is assigned to an environment variable, which is used as the basis for a dynamic matrix in the next job of the workflow. This will allow for parallelism in executing tests for each service. A step has been added to that subsequent workflow to show that information can be retrieved from the matrix items, which are maps rather than strings.

## Jira Issue ID

[TRT-627](https://bugs.earthdata.nasa.gov/browse/TRT-627)

## Local Test Steps

* Look at the version I have got running in [my fork of this repository](https://github.com/owenlittlejohns/harmony-autotester).
* As a single difference, I added a manual trigger (a `workflow_dispatch` event), so the tests could be manually executed - see successful workflow run [here](https://github.com/owenlittlejohns/harmony-autotester/actions/runs/13577719100). Things to check:
  * The first job (identify_all_services) ran successfully.
  * Multiple jobs were spawned for the second step. These should be named for different Harmony services.
* The main trigger for this job is a scheduled trigger at 2:05am. I believe this is UTC, so will execute at 9:05pm EST. If you are looking at this PR on Friday the 28th February or later, see if the forked repository ran a scheduled execution of the workflow (I'll update this PR if I see it did).

## PR Acceptance Checklist
* [x] Jira ticket acceptance criteria met.
* [ ] `CHANGELOG.md` updated to include high level summary of PR changes.
* [ ] Documentation updated (if needed).