### PR TITLE
TRT-629: Fix URL for GitHub comments.

### DIFF
--- a/bin/update_github_issues.py
+++ b/bin/update_github_issues.py
@@ -333,7 +333,7 @@ def create_or_update_issue_comment(
         comment_response = requests.patch(
             (
                 f'https://api.github.com/repos/{github_repository}/issues'
-                f'/{service_issue_number}/comments/{comment_id}'
+                f'/comments/{comment_id}'
             ),
             headers={
                 'Accept': 'application/vnd.github+json',
@@ -344,10 +344,7 @@ def create_or_update_issue_comment(
     else:
         # Create a new comment:
         comment_response = requests.post(
-            (
-                f'https://api.github.com/repos/{github_repository}/issues'
-                f'/{service_issue_number}/comments'
-            ),
+            'https://api.github.com/repos/{github_repository}/issues/comments',
             headers={
                 'Accept': 'application/vnd.github+json',
                 'Authorization': f'token {github_token}',


### PR DESCRIPTION
## Description

This PR fixes the URL used to publish comments to GitHub issues. (When testing in my fork I had previously seen HyBIG tests had failed, but missed that they didn't actually complete the workflow.)

[Example run](https://github.com/owenlittlejohns/harmony-autotester/actions/runs/14717341623) showing full execution getting beyond this issue in my fork, here.

## Jira Issue ID

[TRT-629](https://bugs.earthdata.nasa.gov/browse/TRT-629)

## Local Test Steps

Review the example run from my fork. (And unlike me last time around, actually check that it got all the way through the workflow)

## PR Acceptance Checklist
* [x] Jira ticket acceptance criteria met.
* [x] `CHANGELOG.md` updated to include high level summary of PR changes.
* [x] Documentation updated (if needed).