### PR TITLE
TRT-TASK: Add .snyk files to ensure correct Python versions used.

### DIFF
--- a/tests/.snyk
+++ b/tests/.snyk
@@ -1,0 +1,5 @@
+
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+language-settings:
+  python: "3.12"

--- a/tests/hybig/.snyk
+++ b/tests/hybig/.snyk
@@ -1,0 +1,5 @@
+
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+language-settings:
+  python: "3.12"

--- a/tests/net2cog/.snyk
+++ b/tests/net2cog/.snyk
@@ -1,0 +1,5 @@
+
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+language-settings:
+  python: "3.12"


### PR DESCRIPTION
## Description

This PR is an attempt to force Snyk to build dependency trees for all requirements files under the expected version of Python. Currently, only `dev-requirements.txt` is using the version specified in `.snyk`. Information from the [Snyk documentation](https://docs.snyk.io/manage-risk/policies/the-.snyk-file#use-the-.snyk-file-with-snyk-open-source):

> The .snyk file is generally located at the root of your Project. However, for SCM imports, the .snyk file must be in the same directory as any file needed for scanning to which it relates, for example, a manifest file. See [Use the ](https://docs.snyk.io/manage-risk/policies/the-.snyk-file#use-the-.snyk-file-with-monorepos-and-complex-projects).snyk[ file with monorepos and complex Projects](https://docs.snyk.io/manage-risk/policies/the-.snyk-file#use-the-.snyk-file-with-monorepos-and-complex-projects).

## Jira Issue ID

N/A

## Local Test Steps

Once merged, see what the versions of Python used for the scans for `tests/common_requirements.txt`, `tests/hybig/requirements.txt` and `tests/net2cog/requirements.txt` are in the Snyk console.

## PR Acceptance Checklist
* ~~Jira ticket acceptance criteria met.~~
* ~~`CHANGELOG.md` updated to include high level summary of PR changes.~~
* [x] Documentation updated (if needed).