### PR TITLE
Fixed link title access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ The Harmony Autotester follows semantic versioning. All notable changes to this
 project will be documented in this file. The format is based on [Keep a
 Changelog](http://keepachangelog.com/en/1.0.0/).
 
-## [vX.Y.Z] - 2025-09-23
+## [vX.Y.Z] - 2026-05-07
+
+### Fixed:
+
+- Fixes incorrect access in net2cog test to the filename from the Harmony result JSON
+  by requesting the correct key from the result dictionary.
 
 ### Changed:
 

--- a/tests/net2cog/test_net2cog.py
+++ b/tests/net2cog/test_net2cog.py
@@ -67,6 +67,6 @@ def ensure_correct_files_created(harmony_result_json_links: list[dict]):
     assert len(data_links) > 1, 'Should have at least 1 COG output'
 
     # All output files should have the correct suffix and extension.
-    assert all(link['title'].endswith('_reformatted.tif') for link in data_links), (
+    assert all(link['href'].endswith('_reformatted.tif') for link in data_links), (
         'Not all data links are GeoTIFFs'
     )

--- a/tests/net2cog/test_net2cog.py
+++ b/tests/net2cog/test_net2cog.py
@@ -67,6 +67,6 @@ def ensure_correct_files_created(harmony_result_json_links: list[dict]):
     assert len(data_links) > 1, 'Should have at least 1 COG output'
 
     # All output files should have the correct suffix and extension.
-    assert all(data_link.endswith('_reformatted.tif') for data_link in data_links), (
+    assert all(link['title'].endswith('_reformatted.tif') for link in data_links), (
         'Not all data links are GeoTIFFs'
     )


### PR DESCRIPTION
## Description

This PR fixes incorrect access in net2cog test to the filename from the Harmony result JSON by requesting the correct key from the result dictionary.

Example of the result dictionary:
```
"links": [
    {
        "title": "STAC catalog",
        "href": "https://harmony.uat.earthdata.nasa.gov/stac/e1192b1f-c2bd-4014-9330-eb626f0c4265/",
        "rel": "stac-catalog-json",
        "type": "application/json"
    },
    {
        "href": "https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-staging/public/e1192b1f-c2bd-4014-9330-eb626f0c4265/9479024/TEMPO_O3TOT_L3_V03_20240328T114338Z_S003_weight_reformatted.tif",
        "title": "TEMPO_O3TOT_L3_V03_20240328T114338Z_S003_weight_reformatted.tif",
        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
        "rel": "data",
        "bbox": [
            -110.66,
            17.26,
            -19.92,
            63.72
        ],
        "temporal": {
            "start": "2024-03-28T11:43:38.000Z",
            "end": "2024-03-28T12:23:24.000Z"
        }
    }
]
```

## PR Acceptance Checklist
* [ ] Jira ticket acceptance criteria met.
* [x] `CHANGELOG.md` updated to include high level summary of PR changes.
* [ ] Documentation updated (if needed).
