### PR TITLE
Replace manual batchee grouping in harmony-autotester with batchee function

### DIFF
--- a/tests/sambah/test_sambah.py
+++ b/tests/sambah/test_sambah.py
@@ -1,8 +1,7 @@
 """pytest suite for Harmony sambah converter."""
 
-from collections import defaultdict
-
 import earthaccess
+from batchee.harmony.util import _group_batch_indices
 from batchee.tempo_filename_parser import get_batch_indices
 from harmony import BBox, CapabilitiesRequest, Collection
 
@@ -38,10 +37,7 @@ def test_sambah(failed_tests, harmony_client, service_collection, earthaccess_lo
         granule_names = [get_granule_filename(granule) for granule in granules]
         batch_indices = get_batch_indices(granule_names)
 
-        grouped = defaultdict(list)
-
-        for k, v in zip(batch_indices, granules, strict=False):
-            grouped[k].append(v)
+        grouped = _group_batch_indices(batch_indices, granule_names)
 
         scans = sorted(grouped.values(), key=len)
         assert scans, 'No compatible scans were found'


### PR DESCRIPTION
## Description

Replaced manual batchee grouping in the sambah test with batchee grouping utility function

## Jira Issue ID

[TRADE-1227](https://bugs.earthdata.nasa.gov/browse/TRADE-1227)

## Local Test Steps

Run the sambah test

## PR Acceptance Checklist
* [ ] Jira ticket acceptance criteria met.
* [ ] `CHANGELOG.md` updated to include high level summary of PR changes.
* [ ] Documentation updated (if needed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test coverage to use the shared batch-index grouping behavior.
  * Simplified test setup while preserving existing validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->